### PR TITLE
CHG: raise time between createStage and renderImage

### DIFF
--- a/lib/gallery.js
+++ b/lib/gallery.js
@@ -105,7 +105,7 @@ Gallery = (function(superClass) {
           });
         });
       };
-    })(this)), 5);
+    })(this)), 200);
   };
 
   Gallery.prototype._bind = function() {

--- a/src/gallery.coffee
+++ b/src/gallery.coffee
@@ -95,7 +95,7 @@ class Gallery extends SimpleModule
         @_initRoutate()
         @gallery.one @util.transitionEnd(), (e) =>
           @_zoomInPosition()
-    ), 5
+    ), 200
 
 
   _bind: () ->


### PR DESCRIPTION
deatil:

if using fonticons zr-spin to customize loading indicator, the css3 animation may not work in safari, raise time between dom adding and animations